### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/js/src/PaymentHighwayUtility.js
+++ b/js/src/PaymentHighwayUtility.js
@@ -1,5 +1,5 @@
 "use strict";
-const Uuid = require('node-uuid');
+const Uuid = require('uuid');
 class PaymentHighwayUtility {
     /**
      * Cryptographically strong pseudo random number generator.

--- a/package.json
+++ b/package.json
@@ -26,19 +26,19 @@
     "email": "pauli.kostamo@solinor.com",
     "url": "http://paymenthighway.fi/"
   },
-  "repository" : {
-    "type" : "git",
-    "url" : "https://github.com/solinor/paymenthighway-javascript-lib"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/solinor/paymenthighway-javascript-lib"
   },
   "license": "MIT",
   "dependencies": {
     "core-js": "^0.6.0",
     "lodash": "^4.15.0",
     "moment": "^2.15.0",
-    "node-uuid": "^1.4.7",
     "request": "^2.74.0",
     "request-promise": "^4.1.1",
-    "typings": "^1.3.1"
+    "typings": "^1.3.1",
+    "uuid": "^3.0.0"
   },
   "engines": {
     "node": ">=4.3.2"

--- a/ts/src/PaymentHighwayUtility.ts
+++ b/ts/src/PaymentHighwayUtility.ts
@@ -1,4 +1,4 @@
-import * as Uuid from 'node-uuid';
+import * as Uuid from 'uuid';
 
 export class PaymentHighwayUtility {
 


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.