### PR TITLE
Move unit test typings to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,10 +26,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@types/chai": "^3.4.34",
-    "@types/chai-string": "^1.1.30",
     "@types/lodash": "^4.14.43",
-    "@types/mocha": "^2.2.33",
     "@types/node": "^6.0.52",
     "@types/request": "0.0.36",
     "@types/request-promise": "^4.1.33",
@@ -45,6 +42,9 @@
     "node": ">=4.3.2"
   },
   "devDependencies": {
+    "@types/chai": "^3.4.34",
+    "@types/chai-string": "^1.1.30",
+    "@types/mocha": "^2.2.33",
     "chai": "^3.5.0",
     "chai-string": "^1.3.0",
     "del-cli": "^0.2.0",


### PR DESCRIPTION
Getting TypeScript conflicts with Jest from Mocha, the unit test typings shouldn't be installed with the package.